### PR TITLE
cleanup: keep runner alive if a user is logged in

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -28,6 +28,14 @@ function runnerArch() {
   cat "${JOB}/${CUSTOM_ENV_RUNNER}/config.json" | jq -r '.runnerArch'
 }
 
+function waitForUserLogout() {
+    COMMAND="who -s | wc -l"
+    RESULT=$("$SSH" "$(sshUser)@${VM_IP}" "$COMMAND")
+	while (( "$RESULT" > 0 )); do
+		sleep 30
+	done
+}
+
 function terraform-wrapper() {
   while true; do
     COUNT=$(pgrep -cf '^terraform'; true)

--- a/cleanup
+++ b/cleanup
@@ -6,6 +6,9 @@ currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./base.sh
 source "${currentDir}/base.sh"
 
+# if a user is logged in to the runner, wait until they're done
+waitForUserLogout
+
 # we want to run as many commands as possible
 set +e
 


### PR DESCRIPTION
This is a different implementation of
https://github.com/osbuild/osbuild-composer/commit/e869c6ab84a7a27c3cf0b16f212263462e000fea
There is a hard-coded 5 minute timeout for after_script so wait for the
user here instead.

Related documentation link https://docs.gitlab.com/ee/ci/yaml/#after_script