### PR TITLE
base.sh: fix SSH in waitForUserLogout

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -31,7 +31,7 @@ function runnerArch() {
 function waitForUserLogout() {
     COMMAND="who -s | wc -l"
     VM_IP=$(cat "${JOB}/ip")
-    RESULT=$("$SSH" "$(sshUser)@${VM_IP}" "$COMMAND")
+    RESULT=$($SSH "$(sshUser)@${VM_IP}" "$COMMAND")
 	while (( "$RESULT" > 0 )); do
 		sleep 30
 	done


### PR DESCRIPTION
Previously the whole SSH command was passed as one string, that's not what
we want. We actually want to pass the command as an array.