### PR TITLE
base.sh: another fix for waitForUserLogout

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -32,9 +32,10 @@ function waitForUserLogout() {
     COMMAND="who -s | wc -l"
     VM_IP=$(cat "${JOB}/ip")
     RESULT=$($SSH "$(sshUser)@${VM_IP}" "$COMMAND")
-	while (( "$RESULT" > 0 )); do
-		sleep 30
-	done
+    while (( "$RESULT" > 0 )); do
+        sleep 30
+        RESULT=$($SSH "$(sshUser)@${VM_IP}" "$COMMAND")
+    done
 }
 
 function terraform-wrapper() {


### PR DESCRIPTION
The loop never re-checked the number of logged in users and therefore
the RESULT variable stayed the same. This is hopefuly last fix.
