### PR TITLE
cleanup: don't fail the script if the logout waiter fails

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -6,11 +6,11 @@ currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./base.sh
 source "${currentDir}/base.sh"
 
-# if a user is logged in to the runner, wait until they're done
-waitForUserLogout
-
 # we want to run as many commands as possible
 set +e
+
+# if a user is logged in to the runner, wait until they're done
+waitForUserLogout
 
 terraform-wrapper destroy -auto-approve
 


### PR DESCRIPTION
If the instance creation failed, there's no IP and thus waitForUserLogout
fails and with set -e this fails the whole script before terraform destroy
is called.

This commit allows the waiter to fail.