### PR TITLE
aws/tags: add a new set of tags to AWS instances

### DIFF
--- a/prepare
+++ b/prepare
@@ -23,9 +23,19 @@ git -C "$TEMP" checkout "$TERRAFORM_COMMIT"
 
 mv "$TEMP" "$JOB"
 
+INTERNAL_NETWORK="false"
 if [ "${CUSTOM_ENV_INTERNAL_NETWORK:-}" ]; then
-  echo "internal_network = true" > "$JOB/${CUSTOM_ENV_RUNNER}/terraform.tfvars"
+  INTERNAL_NETWORK="true"
 fi
+
+tee "$JOB/${CUSTOM_ENV_RUNNER}/terraform.tfvars" << EOF
+internal_network = ${INTERNAL_NETWORK}
+job_name         = ${CUSTOM_ENV_CI_JOB_NAME}
+project          = ${CUSTOM_ENV_CI_PROJECT_NAME}
+branch           = ${CUSTOM_ENV_CI_COMMIT_BRANCH}
+pipeline_id      = ${CUSTOM_ENV_CI_PIPELINE_ID}
+pipeline_source  = ${CUSTOM_ENV_CI_PIPELINE_SOURCE}
+EOF
 
 # Spin up the instance
 terraform-wrapper init


### PR DESCRIPTION
In order to be able to perform fine grained analytics on our AWS budget (e.g monitor closely our CI usage). This commit brings up new tags to categorize what are each instance used for.

Linked to https://github.com/osbuild/gitlab-ci-terraform/pull/77