### PR TITLE
prepare: add a default value for branch

### DIFF
--- a/prepare
+++ b/prepare
@@ -32,7 +32,7 @@ tee "$JOB/${CUSTOM_ENV_RUNNER}/terraform.tfvars" << EOF
 internal_network = ${INTERNAL_NETWORK}
 job_name         = "${CUSTOM_ENV_CI_JOB_NAME}"
 project          = "${CUSTOM_ENV_CI_PROJECT_NAME}"
-branch           = "${CUSTOM_ENV_CI_COMMIT_BRANCH}"
+branch           = "${CUSTOM_ENV_CI_COMMIT_BRANCH:-unset}"
 pipeline_id      = "${CUSTOM_ENV_CI_PIPELINE_ID}"
 pipeline_source  = "${CUSTOM_ENV_CI_PIPELINE_SOURCE}"
 EOF


### PR DESCRIPTION
I've just realized we have a "branch-less" pipelines in one of our side-projects, see
https://gitlab.com/redhat/services/products/image-builder/ci/anaconda-preview-builder

It turns out that this project have pipelines without a branch because we use merge trains there. So this commit just adds a fallback value if a branch is not there.