### PR TITLE
prepare: add "|| true" to dnf command

### DIFF
--- a/prepare
+++ b/prepare
@@ -113,7 +113,7 @@ $SSH "$(sshUser)@${VM_IP}" sudo dnf clean all
 echo "INFO: Will install gitlab-runner"
 for _LOOP_COUNTER in {0..30}; do
     set +e
-    $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y "https://gitlab-runner-downloads.s3.amazonaws.com/latest/rpm/gitlab-runner_$(runnerArch).rpm"
+    $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y "https://gitlab-runner-downloads.s3.amazonaws.com/latest/rpm/gitlab-runner_$(runnerArch).rpm" || true
     set -e
 
     if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner"; then


### PR DESCRIPTION
Gitlab runner executes cleanup whenever a command with non-zero exit code is executed regardless of having "set +e". Adding "|| true" to a command that's expected to fail prevents that.