### PR TITLE
cleanup: export GCP credentials again for cleanup

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -5,6 +5,8 @@
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=./base.sh
 source "${currentDir}/base.sh"
+# Set the GCP credentials again for cleanup
+export GOOGLE_APPLICATION_CREDENTIALS="${JOB}/gcp-credentials.json"
 
 # we want to run as many commands as possible
 set +e


### PR DESCRIPTION
The cleanup fails without this... This should fix it, but maybe we can export the variable in `base.sh` and just create the credentials file in `prepare`? Would save us 1 lines I guess...