### PR TITLE
Prepare: install also gitlab-runner-helper-images RPM (COMPOSER-2423)

### DIFF
--- a/prepare
+++ b/prepare
@@ -124,7 +124,9 @@ $SSH "$(sshUser)@${VM_IP}" sudo dnf clean all || true
 echo "INFO: Will install gitlab-runner"
 for _LOOP_COUNTER in {0..30}; do
     set +e
-    $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y "https://gitlab-runner-downloads.s3.amazonaws.com/latest/rpm/gitlab-runner_$(runnerArch).rpm" || true
+    $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y \
+        "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner-helper-images.rpm" \
+        "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_$(runnerArch).rpm" || true
     set -e
 
     if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner"; then


### PR DESCRIPTION
Update the manual installation of the gitlab-runner based on the official documentation [0].

Specifically:
 - Update repo URLs
 - Also install the gitlab-runner-helper-images RPM, which is a dependency of gitlab-runner RPM.

[0] https://docs.gitlab.com/runner/install/linux-manually.html#download