### PR TITLE
prepare: skip runner installation if present

### DIFF
--- a/prepare
+++ b/prepare
@@ -148,16 +148,17 @@ $SSH "$(sshUser)@${VM_IP}" sudo dnf clean all || true
 # actually installed
 echo "INFO: Will install gitlab-runner"
 for _LOOP_COUNTER in {0..30}; do
+    if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner"; then
+        echo "INFO: gitlab-runner has been installed"
+        break
+    fi
+
     set +e
     $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y \
         "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner-helper-images.rpm" \
         "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_$(runnerArch).rpm" || true
     set -e
 
-    if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner"; then
-        echo "INFO: gitlab-runner has been installed"
-        break
-    fi
     echo "INFO: retrying ...."
     sleep 10
 done


### PR DESCRIPTION
SSIA

Solves:

```
INFO: Will install gitlab-runner
Updating Subscription Management repositories.
Red Hat CodeReady Linux Builder for RHEL 10 x86 2.8 MB/s | 972 kB     00:00    
Red Hat Enterprise Linux 10 for x86_64 - BaseOS  57 MB/s |  50 MB     00:00    
Red Hat Enterprise Linux 10 for x86_64 - AppStr  12 MB/s | 4.4 MB     00:00    
gitlab-runner-helper-images.rpm                  94 MB/s | 507 MB     00:05    
[MIRROR] gitlab-runner_amd64.rpm: Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
[MIRROR] gitlab-runner_amd64.rpm: Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
[MIRROR] gitlab-runner_amd64.rpm: Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
[MIRROR] gitlab-runner_amd64.rpm: Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
[FAILED] gitlab-runner_amd64.rpm: Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
Status code: 403 for https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_amd64.rpm (IP: 52.217.49.142)
gitlab-runner-18.9.0-1.x86_64
INFO: gitlab-runner has been installed
gitlab-runner-18.9.0-1.x86_64
```