### PR TITLE
prepare: support force updating gitlab-runner

### DIFF
--- a/prepare
+++ b/prepare
@@ -148,7 +148,7 @@ $SSH "$(sshUser)@${VM_IP}" sudo dnf clean all || true
 # actually installed
 echo "INFO: Will install gitlab-runner"
 for _LOOP_COUNTER in {0..30}; do
-    if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner"; then
+    if $SSH "$(sshUser)@${VM_IP}" "rpm -q gitlab-runner" && [[ "${CUSTOM_ENV_FORCE_UPDATE_RUNNER:-0}" != "1" ]]; then
         echo "INFO: gitlab-runner has been installed"
         break
     fi


### PR DESCRIPTION
There are certain cases where it makes sense to update the gitlab runner even if it is pre-installed. For instance when backporting tests often run against older ci images. These older ci images have gitlab-runner installed, but not necessarily a new enough version with all the required options.

This allows ci pipelines to request an update of the runners before continuing.