### PR TITLE
prepare: stop updating runner on succesful dnf install

### DIFF
--- a/prepare
+++ b/prepare
@@ -156,8 +156,14 @@ for _LOOP_COUNTER in {0..30}; do
     set +e
     $SSH "$(sshUser)@${VM_IP}" sudo dnf install -y \
         "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner-helper-images.rpm" \
-        "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_$(runnerArch).rpm" || true
+        "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/rpm/gitlab-runner_$(runnerArch).rpm"
+    EXIT_CODE="$?"
     set -e
+
+    if [[ "$EXIT_CODE" == "0" ]]; then
+        echo "INFO: gitlab runner has been installed"
+        break
+    fi
 
     echo "INFO: retrying ...."
     sleep 10


### PR DESCRIPTION
With FORCE_UPDATE_RUNNER it tried to upgrade the runner 30 times. If the dnf command succeeded, assume the upgrade worked.